### PR TITLE
Fix for TypeScript package corruption in jenkins

### DIFF
--- a/src/proxy-ui-api/frontend/package-lock.json
+++ b/src/proxy-ui-api/frontend/package-lock.json
@@ -13913,9 +13913,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
       "dev": true
     },
     "uglify-js": {

--- a/src/proxy-ui-api/frontend/package.json
+++ b/src/proxy-ui-api/frontend/package.json
@@ -37,7 +37,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "ts-jest": "^23.0.0",
-    "typescript": "^3.3.3333",
+    "typescript": "3.3.3",
     "vue-cli-plugin-vuetify": "^0.4.6",
     "vue-template-compiler": "^2.6.7",
     "vuetify-loader": "^1.2.1"


### PR DESCRIPTION
This might fix the mysterious jenkins build corruption issue.
Related: https://github.com/Microsoft/TypeScript/issues/30077

Typescript version is now locked to 3.3.3 because newer version than 3.3.3333 is not yet available.
