### PR TITLE
Fix for json file related build error

### DIFF
--- a/src/proxy-ui-api/frontend/tsconfig.json
+++ b/src/proxy-ui-api/frontend/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [


### PR DESCRIPTION
This should fix the build error that happens when importing mock json files in vuex unit tests.