### PR TITLE
XRDDEV-356 Fix duplicate params in Gradle bootRun task

### DIFF
--- a/src/proxy-ui-api/build.gradle
+++ b/src/proxy-ui-api/build.gradle
@@ -45,7 +45,8 @@ apply plugin: 'org.openapi.generator'
 bootRun {
     jvmArgs = ["-Dspring.output.ansi.enabled=ALWAYS"]
     if (project.hasProperty('args')) {
-        args project.args.split(',')
+        def params = project.args.tokenize(',')
+        args = params
     }
 }
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/RestApiApplication.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/RestApiApplication.java
@@ -29,9 +29,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.PropertySource;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
 /**
  * main spring boot application.
  */
@@ -44,9 +41,6 @@ public class RestApiApplication {
      * start application
      */
     public static void main(String[] args) {
-        // bootRun seems to duplicate parameters in some situations
-        // with our gradle configuration
-        HashSet<String> filtered = new HashSet(Arrays.asList(args));
-        SpringApplication.run(RestApiApplication.class, filtered.toArray(new String[]{}));
+        SpringApplication.run(RestApiApplication.class, args);
     }
 }


### PR DESCRIPTION
- Fixed by using a separate variable for split `args` string
- Changed `split()` to `tokenize()` which will ignore empty values between sequential commas