### PR TITLE
vee-validate quickfix

### DIFF
--- a/src/proxy-ui-api/frontend/package-lock.json
+++ b/src/proxy-ui-api/frontend/package-lock.json
@@ -14315,9 +14315,9 @@
       "dev": true
     },
     "vee-validate": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-2.2.0.tgz",
-      "integrity": "sha512-s72VQcl1DWTNQKQyHtUDcU536dIx/GYDnCObDj4AXDZtWnqM3rXbgp7FCT3D2q9HFKw7IykW9bVrClhPBeQnrw=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-2.2.5.tgz",
+      "integrity": "sha512-YzPxVqeSaoiO9OL2S+O1BZhsIkwubb9hrXeNQDeGIXautwZs2hWCYq2A6iL9zWcTY7H5z99JaZzH3P+dCVfNqw=="
     },
     "vendors": {
       "version": "1.0.2",

--- a/src/proxy-ui-api/frontend/package.json
+++ b/src/proxy-ui-api/frontend/package.json
@@ -17,7 +17,7 @@
     "file-saver": "^2.0.1",
     "lodash": "^4.17.11",
     "roboto-fontface": "*",
-    "vee-validate": "^2.2.0",
+    "vee-validate": "2.2.5",
     "vue": "^2.6.10",
     "vue-router": "^3.0.1",
     "vuetify": "^1.5.9",


### PR DESCRIPTION
## Description

Lock the version of vee-validate to 2.2.5 because of the next version (2.2.6) has a currently unsolved linting error. 

Please include a summary of the change

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [ ] I have made corresponding changes to the documentation
- [ ] The new code has sufficient test coverage
- [ ] The build, unit and integration tests pass
- [ ] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or new issues have been added to [Front-end build process](https://confluence.niis.org/display/XRDDEV/Front-end+build+process) tracking table and accepted
- [ ] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [ ] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [ ] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")
