### PR TITLE
XRDDEV-570 Groups API // refactored from String id to Long id

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/GroupConverter.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/GroupConverter.java
@@ -60,7 +60,7 @@ public class GroupConverter {
     public Group convert(LocalGroupType localGroupType) {
         Group group = new Group();
 
-        group.setId(localGroupType.getId());
+        group.setId(String.valueOf(localGroupType.getId()));
         group.setCode(localGroupType.getGroupCode());
         group.setDescription(localGroupType.getDescription());
         group.setUpdatedAt(FormatUtils.fromDateToOffsetDateTime(localGroupType.getUpdated()));

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/GroupsApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/GroupsApiController.java
@@ -35,6 +35,7 @@ import org.niis.xroad.restapi.openapi.model.Group;
 import org.niis.xroad.restapi.openapi.model.InlineObject3;
 import org.niis.xroad.restapi.openapi.model.InlineObject4;
 import org.niis.xroad.restapi.service.GroupService;
+import org.niis.xroad.restapi.util.FormatUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -75,42 +76,45 @@ public class GroupsApiController implements GroupsApi {
 
     @Override
     @PreAuthorize("hasAuthority('VIEW_CLIENT_LOCAL_GROUPS')")
-    public ResponseEntity<Group> getGroup(String groupId) {
-        LocalGroupType localGroupType = getLocalGroupType(groupId);
+    public ResponseEntity<Group> getGroup(String groupIdString) {
+        LocalGroupType localGroupType = getLocalGroupType(groupIdString);
         return new ResponseEntity<>(groupConverter.convert(localGroupType), HttpStatus.OK);
     }
 
     @Override
     @PreAuthorize("hasAuthority('EDIT_LOCAL_GROUP_DESC')")
-    public ResponseEntity<Group> updateGroup(String groupId, String description) {
+    public ResponseEntity<Group> updateGroup(String groupIdString, String description) {
+        Long groupId = FormatUtils.parseLongIdOrThrowNotFound(groupIdString);
         LocalGroupType localGroupType = groupsService.updateDescription(groupId, description);
         return new ResponseEntity<>(groupConverter.convert(localGroupType), HttpStatus.OK);
     }
 
     @Override
     @PreAuthorize("hasAuthority('EDIT_LOCAL_GROUP_MEMBERS')")
-    public ResponseEntity<Void> addGroupMember(String groupId, InlineObject3 memberItemsWrapper) {
+    public ResponseEntity<Void> addGroupMember(String groupIdString, InlineObject3 memberItemsWrapper) {
         if (memberItemsWrapper == null || memberItemsWrapper.getItems() == null
                 || memberItemsWrapper.getItems().size() < 1) {
             throw new InvalidParametersException("missing member id");
         }
         // remove duplicates
         List<String> uniqueIds = new ArrayList<>(new HashSet<>(memberItemsWrapper.getItems()));
+        Long groupId = FormatUtils.parseLongIdOrThrowNotFound(groupIdString);
         groupsService.addLocalGroupMembers(groupId, clientConverter.convertIds(uniqueIds));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @Override
     @PreAuthorize("hasAuthority('DELETE_LOCAL_GROUP')")
-    public ResponseEntity<Void> deleteGroup(String groupId) {
+    public ResponseEntity<Void> deleteGroup(String groupIdString) {
+        Long groupId = FormatUtils.parseLongIdOrThrowNotFound(groupIdString);
         groupsService.deleteLocalGroup(groupId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @Override
     @PreAuthorize("hasAuthority('EDIT_LOCAL_GROUP_MEMBERS')")
-    public ResponseEntity<Void> deleteGroupMember(String groupId, InlineObject4 memberItemsWrapper) {
-        LocalGroupType localGroupType = getLocalGroupType(groupId);
+    public ResponseEntity<Void> deleteGroupMember(String groupIdString, InlineObject4 memberItemsWrapper) {
+        LocalGroupType localGroupType = getLocalGroupType(groupIdString);
         groupsService.deleteGroupMember(localGroupType, clientConverter.convertIds(memberItemsWrapper.getItems()));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
@@ -119,7 +123,8 @@ public class GroupsApiController implements GroupsApi {
      * Read one group from DB, throw NotFoundException or
      * BadRequestException is needed
      */
-    private LocalGroupType getLocalGroupType(String groupId) {
+    private LocalGroupType getLocalGroupType(String groupIdString) {
+        Long groupId = FormatUtils.parseLongIdOrThrowNotFound(groupIdString);
         LocalGroupType localGroupType = groupsService.getLocalGroup(groupId);
         if (localGroupType == null) {
             throw new NotFoundException("LocalGroup with not found");

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServiceDescriptionsApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ServiceDescriptionsApiController.java
@@ -25,9 +25,9 @@
 package org.niis.xroad.restapi.openapi;
 
 import lombok.extern.slf4j.Slf4j;
-import org.niis.xroad.restapi.exceptions.NotFoundException;
 import org.niis.xroad.restapi.openapi.model.InlineObject10;
 import org.niis.xroad.restapi.service.ServiceDescriptionService;
+import org.niis.xroad.restapi.util.FormatUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -65,24 +65,9 @@ public class ServiceDescriptionsApiController implements ServiceDescriptionsApi 
     @Override
     @PreAuthorize("hasAuthority('ENABLE_DISABLE_WSDL')")
     public ResponseEntity<Void> enableServiceDescription(String id) {
-        Long serviceDescriptionId = parseServiceDescriptionId(id);
+        Long serviceDescriptionId = FormatUtils.parseLongIdOrThrowNotFound(id);
         serviceDescriptionService.enableServices(Collections.singletonList(serviceDescriptionId));
         return new ResponseEntity<Void>(HttpStatus.OK);
-    }
-
-    /**
-     * in case of NumberFormatException we throw NotFoundException. Client should not
-     * know about id parameter details, such as "it should be numeric" -
-     * the resource with given id just cant be found, and that's all there is to it
-     */
-    private Long parseServiceDescriptionId(String id) {
-        Long serviceDescriptionId = null;
-        try {
-            serviceDescriptionId = Long.valueOf(id);
-        } catch (NumberFormatException nfe) {
-            throw new NotFoundException(nfe);
-        }
-        return serviceDescriptionId;
     }
 
     @Override
@@ -92,7 +77,7 @@ public class ServiceDescriptionsApiController implements ServiceDescriptionsApi 
         if (inlineObject9 != null) {
             disabledNotice = inlineObject9.getDisabledNotice();
         }
-        Long serviceDescriptionId = parseServiceDescriptionId(id);
+        Long serviceDescriptionId = FormatUtils.parseLongIdOrThrowNotFound(id);
         serviceDescriptionService.disableServices(Collections.singletonList(serviceDescriptionId),
                 disabledNotice);
         return new ResponseEntity<Void>(HttpStatus.OK);

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/GroupService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/GroupService.java
@@ -79,8 +79,8 @@ public class GroupService {
      * @return LocalGroupType
      */
     @PreAuthorize("hasAuthority('VIEW_CLIENT_LOCAL_GROUPS')")
-    public LocalGroupType getLocalGroup(String groupId) {
-        return groupsRepository.getLocalGroup(Long.parseLong(groupId));
+    public LocalGroupType getLocalGroup(Long groupId) {
+        return groupsRepository.getLocalGroup(groupId);
     }
 
     /**
@@ -88,7 +88,7 @@ public class GroupService {
      * @return LocalGroupType
      */
     @PreAuthorize("hasAuthority('EDIT_LOCAL_GROUP_DESC')")
-    public LocalGroupType updateDescription(String groupId, String description) {
+    public LocalGroupType updateDescription(Long groupId, String description) {
         LocalGroupType localGroupType = getLocalGroup(groupId);
         if (localGroupType == null) {
             throw new NotFoundException("LocalGroup with id " + groupId + " not found");
@@ -128,7 +128,7 @@ public class GroupService {
      * @param memberIds
      */
     @PreAuthorize("hasAuthority('EDIT_LOCAL_GROUP_MEMBERS')")
-    public void addLocalGroupMembers(String groupId, List<ClientId> memberIds) {
+    public void addLocalGroupMembers(Long groupId, List<ClientId> memberIds) {
         LocalGroupType localGroupType = getLocalGroup(groupId);
         if (localGroupType == null) {
             throw new NotFoundException("LocalGroup with id " + groupId + " not found");
@@ -161,7 +161,7 @@ public class GroupService {
      * @param groupId
      */
     @PreAuthorize("hasAuthority('DELETE_LOCAL_GROUP')")
-    public void deleteLocalGroup(String groupId) {
+    public void deleteLocalGroup(Long groupId) {
         LocalGroupType existingLocalGroupType = getLocalGroup(groupId);
         if (existingLocalGroupType == null) {
             throw new NotFoundException("LocalGroup with id " + groupId + " not found");

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/util/FormatUtils.java
@@ -24,6 +24,8 @@
  */
 package org.niis.xroad.restapi.util;
 
+import org.niis.xroad.restapi.exceptions.NotFoundException;
+
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -44,5 +46,22 @@ public final class FormatUtils {
      */
     public static OffsetDateTime fromDateToOffsetDateTime(Date date) {
         return date.toInstant().atOffset(ZoneOffset.UTC);
+    }
+
+    /**
+     * in case of NumberFormatException we throw NotFoundException. Client should not
+     * know about id parameter details, such as "it should be numeric" -
+     * the resource with given id just cant be found, and that's all there is to it
+     * @param id as String
+     * @return id as Long
+     */
+    public static Long parseLongIdOrThrowNotFound(String id) throws NotFoundException {
+        Long groupId = null;
+        try {
+            groupId = Long.valueOf(id);
+        } catch (NumberFormatException nfe) {
+            throw new NotFoundException(nfe);
+        }
+        return groupId;
     }
 }

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -3456,10 +3456,11 @@ components:
         - description
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          format: text
           description: unique identifier
           example: 123
+          readOnly: true
         code:
           type: string
           format: text

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/GroupsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/GroupsApiControllerIntegrationTest.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -67,6 +68,7 @@ import static org.mockito.Mockito.when;
 @Slf4j
 public class GroupsApiControllerIntegrationTest {
     private static final String GROUP_ID = "1";
+    private static final String INVALID_GROUP_ID = "NOT_VALID";
     public static final String CLIENT_ID_SS1 = "FI:GOV:M1:SS1";
     public static final String CLIENT_ID_SS2 = "FI:GOV:M1:SS2";
     public static final String GROUP_DESC = "GROUP_DESC";
@@ -112,6 +114,12 @@ public class GroupsApiControllerIntegrationTest {
         ResponseEntity<Group> response =
                 groupsApiController.getGroup(GROUP_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
+        try {
+            groupsApiController.getGroup(INVALID_GROUP_ID);
+            fail("should throw NotFoundException");
+        } catch (NotFoundException expected) {
+            // nothing should be found
+        }
     }
 
     @Test
@@ -132,6 +140,7 @@ public class GroupsApiControllerIntegrationTest {
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
         try {
             groupsApiController.getGroup(GROUP_ID);
+            fail("should throw NotFoundException");
         } catch (NotFoundException expected) {
             // success
         }
@@ -176,6 +185,7 @@ public class GroupsApiControllerIntegrationTest {
         try {
             groupsApiController.addGroupMember(GROUP_ID,
                     new InlineObject3().items(Collections.singletonList(CLIENT_ID_SS2)));
+            fail("should throw ConflictException");
         } catch (ConflictException expected) {
             // expected exception
         }

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/GroupsServiceIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/GroupsServiceIntegrationTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.fail;
 @Transactional
 public class GroupsServiceIntegrationTest {
 
-    private static final String GROUP_ID = "1";
+    private static final Long GROUP_ID = 1L;
     private static final String NEW_GROUPCODE = "groupX";
     private static final String GROUP_DESC = "foo";
     private static final String NEW_GROUP_DESC = "bar";
@@ -76,7 +76,7 @@ public class GroupsServiceIntegrationTest {
         localGroupType.setUpdated(new Date());
         localGroupType = groupsService.addLocalGroup(id, localGroupType);
 
-        LocalGroupType localGroupTypeFromDb = groupsService.getLocalGroup(localGroupType.getId().toString());
+        LocalGroupType localGroupTypeFromDb = groupsService.getLocalGroup(localGroupType.getId());
 
         assertEquals(NEW_GROUPCODE, localGroupTypeFromDb.getGroupCode());
         assertEquals(GROUP_DESC, localGroupTypeFromDb.getDescription());


### PR DESCRIPTION
## Description

Groups API related primary key ids have been refactored from String to Long. 

* `parseLongIdOrThrowNotFound` method moved into `FormatUtils` util class
* fixed tests and added related additions to them
* updated [API guidelines](https://confluence.niis.org/pages/viewpage.action?pageId=8520435)

**It is probably a good idea to merge this into develop before** #58 #59 **AND** #61

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [x] I have made corresponding changes to the documentation
- [x] The new code has sufficient test coverage
- [x] The build, unit and integration tests pass
- [x] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or new issues have been added to [Front-end build process](https://confluence.niis.org/display/XRDDEV/Front-end+build+process) tracking table and accepted
- [x] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [x] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [x] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")
