### PR TITLE
XRDDEV-509 Search clients // fix bug where no client status was shown

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
@@ -75,10 +75,10 @@ public class ClientConverter {
         client.setSubsystemCode(clientType.getIdentifier().getSubsystemCode());
         client.setMemberName(globalConfService.getMemberName(clientType.getIdentifier()));
         Optional<ClientStatus> status = ClientStatusMapping.map(clientType.getClientStatus());
-        client.setStatus(status.get());
+        client.setStatus(status.orElse(null));
         Optional<ConnectionType> connectionTypeEnum =
                 ConnectionTypeMapping.map(clientType.getIsAuthentication());
-        client.setConnectionType(connectionTypeEnum.get());
+        client.setConnectionType(connectionTypeEnum.orElse(null));
         return client;
     }
 

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/converter/ClientConverter.java
@@ -83,6 +83,18 @@ public class ClientConverter {
     }
 
     /**
+     * convert a list of ClientType into a list of openapi Client class
+     * @param clientTypes
+     * @return
+     */
+    public List<Client> convert(List<ClientType> clientTypes) {
+        return clientTypes
+                .stream()
+                .map(this::convert)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Convert ClientId into encoded member id
      * @param clientId
      * @return

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ClientsApiController.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/openapi/ClientsApiController.java
@@ -135,7 +135,7 @@ public class ClientsApiController implements ClientsApi {
             String memberCode, String subsystemCode, Boolean showMembers, Boolean internalSearch) {
         boolean unboxedShowMembers = Boolean.TRUE.equals(showMembers);
         boolean unboxedInternalSearch = Boolean.TRUE.equals(internalSearch);
-        List<Client> clients = clientConverter.convertMemberInfosToClients(clientService.findClients(name,
+        List<Client> clients = clientConverter.convert(clientService.findClients(name,
                 instance, memberClass, memberCode, subsystemCode, unboxedShowMembers, unboxedInternalSearch));
         return new ResponseEntity<>(clients, HttpStatus.OK);
     }

--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/GroupService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/GroupService.java
@@ -24,7 +24,6 @@
  */
 package org.niis.xroad.restapi.service;
 
-import ee.ria.xroad.common.conf.globalconf.MemberInfo;
 import ee.ria.xroad.common.conf.serverconf.model.ClientType;
 import ee.ria.xroad.common.conf.serverconf.model.GroupMemberType;
 import ee.ria.xroad.common.conf.serverconf.model.LocalGroupType;
@@ -135,11 +134,11 @@ public class GroupService {
         }
         List<GroupMemberType> membersToBeAdded = new ArrayList<>(memberIds.size());
         memberIds.forEach(memberId -> {
-            Optional<MemberInfo> foundMember = clientService.findByClientId(memberId);
+            Optional<ClientType> foundMember = clientService.findByClientId(memberId);
             if (!foundMember.isPresent()) {
                 throw new NotFoundException("client with id " + memberId.toShortString() + " not found");
             }
-            ClientId clientIdToBeAdded = foundMember.get().getId();
+            ClientId clientIdToBeAdded = foundMember.get().getIdentifier();
             boolean isAdded = localGroupType.getGroupMember().stream().anyMatch(groupMemberType ->
                     groupMemberType.getGroupMemberId().toShortString().trim()
                             .equals(clientIdToBeAdded.toShortString().trim()));

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -495,11 +495,6 @@ public class ClientsApiControllerIntegrationTest {
                 true, false);
         assertEquals(HttpStatus.OK, clientsResponse.getStatusCode());
         assertEquals(7, clientsResponse.getBody().size());
-        List<Client> clients = clientsResponse.getBody();
-        clients.forEach(client -> {
-            assertNotNull(client.getConnectionType());
-            assertNotNull(client.getStatus());
-        });
     }
 
     @Test

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -169,7 +169,6 @@ public class ClientsApiControllerIntegrationTest {
                     + "IDI0IDE2OjIxIG5vbi1jZXJ0CmRyd3hyd3hyLXggMiBqYW5uZSBqYW5uZSA0MDk2IGh1aHRpID"
                     + "I0IDE2OjIxIHRpbnkK";
 
-
     @MockBean
     private GlobalConfService globalConfService;
 
@@ -179,7 +178,6 @@ public class ClientsApiControllerIntegrationTest {
     @SpyBean
     // partial mocking, just override getValidatorCommand()
     private WsdlValidator wsdlValidator;
-
 
     @Before
     public void setup() throws Exception {
@@ -480,6 +478,28 @@ public class ClientsApiControllerIntegrationTest {
                 INSTANCE_FI, MEMBER_CLASS_GOV, MEMBER_CODE_M1, SUBSYSTEM1, false, false);
         assertEquals(HttpStatus.OK, clientsResponse.getStatusCode());
         assertEquals(1, clientsResponse.getBody().size());
+        List<Client> clients = clientsResponse.getBody();
+        Client client = clients.get(0);
+        assertEquals(SUBSYSTEM1 + NAME_APPENDIX, client.getMemberName());
+        assertEquals(MEMBER_CLASS_GOV, client.getMemberClass());
+        assertEquals(MEMBER_CODE_M1, client.getMemberCode());
+        assertEquals(SUBSYSTEM1, client.getSubsystemCode());
+        assertEquals(ConnectionType.HTTPS_NO_AUTH, client.getConnectionType());
+        assertEquals(ClientStatus.REGISTERED, client.getStatus());
+    }
+
+    @Test
+    @WithMockUser(authorities = "VIEW_CLIENTS")
+    public void findAllClients() {
+        ResponseEntity<List<Client>> clientsResponse = clientsApiController.getClients(null, null, null, null, null,
+                true, false);
+        assertEquals(HttpStatus.OK, clientsResponse.getStatusCode());
+        assertEquals(7, clientsResponse.getBody().size());
+        List<Client> clients = clientsResponse.getBody();
+        clients.forEach(client -> {
+            assertNotNull(client.getConnectionType());
+            assertNotNull(client.getStatus());
+        });
     }
 
     @Test

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/ClientServiceIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/ClientServiceIntegrationTest.java
@@ -299,70 +299,70 @@ public class ClientServiceIntegrationTest {
     /* Test GLOBAL client search */
     @Test
     public void findGlobalClientsByNameIncludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, null, null,
+        List<ClientType> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, null, null,
                 null, null, true);
         assertEquals(2, clients.size());
     }
 
     @Test
     public void findGlobalClientsByInstanceIncludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, INSTANCE_EE, null,
+        List<ClientType> clients = clientService.findGlobalClients(null, INSTANCE_EE, null,
                 null, null, true);
         assertEquals(4, clients.size());
     }
 
     @Test
     public void findGlobalClientsByClassIncludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, null, MEMBER_CLASS_GOV,
+        List<ClientType> clients = clientService.findGlobalClients(null, null, MEMBER_CLASS_GOV,
                 null, null, true);
         assertEquals(3, clients.size());
     }
 
     @Test
     public void findGlobalClientsByInstanceAndMemberCodeIncludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, INSTANCE_FI, null,
+        List<ClientType> clients = clientService.findGlobalClients(null, INSTANCE_FI, null,
                 MEMBER_CODE_M1, null, true);
         assertEquals(3, clients.size());
     }
 
     @Test
     public void findGlobalClientsByAllTermsIncludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, INSTANCE_FI,
+        List<ClientType> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, INSTANCE_FI,
                 MEMBER_CLASS_GOV, MEMBER_CODE_M1, SUBSYSTEM1, true);
         assertEquals(1, clients.size());
     }
 
     @Test
     public void findGlobalClientsByNameExcludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, null, null,
+        List<ClientType> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, null, null,
                 null, null, false);
         assertEquals(2, clients.size());
     }
 
     @Test
     public void findGlobalClientsByInstanceExcludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, INSTANCE_EE, null,
+        List<ClientType> clients = clientService.findGlobalClients(null, INSTANCE_EE, null,
                 null, null, false);
         assertEquals(2, clients.size());
     }
 
     @Test
     public void findGlobalClientsByClassExcludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, null, MEMBER_CLASS_GOV,
+        List<ClientType> clients = clientService.findGlobalClients(null, null, MEMBER_CLASS_GOV,
                 null, null, false);
         assertEquals(2, clients.size());
     }
 
     @Test
     public void findGlobalClientsByInstanceAndMemberCodeExcludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(null, INSTANCE_FI, null,
+        List<ClientType> clients = clientService.findGlobalClients(null, INSTANCE_FI, null,
                 MEMBER_CODE_M1, null, false);
         assertEquals(2, clients.size());
     }
 
     @Test
     public void findGlobalClientsByAllTermsExcludeMembers() {
-        List<MemberInfo> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, INSTANCE_FI,
+        List<ClientType> clients = clientService.findGlobalClients(SUBSYSTEM1 + NAME_APPENDIX, INSTANCE_FI,
                 MEMBER_CLASS_GOV, MEMBER_CODE_M1, SUBSYSTEM1, false);
         assertEquals(1, clients.size());
     }


### PR DESCRIPTION
## Description

Clients are now searched from global conf AND local db because we need client status and connection type for the local clients. Global clients do not have status or connection type.

Jenkins build: https://jenkins.niis.org/view/api-based-ui/job/rest-ui-build-pull-request/83/console

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [x] I have made corresponding changes to the documentation
- [x] The new code has sufficient test coverage
- [x] The build, unit and integration tests pass
- [x] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or new issues have been added to [Front-end build process](https://confluence.niis.org/display/XRDDEV/Front-end+build+process) tracking table and accepted
- [x] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [x] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [x] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")
