### PR TITLE
XRDDEV-317 selectively ignore audits

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,12 @@ Please include a summary of the change
 - [ ] The new code has sufficient test coverage
 - [ ] The build, unit and integration tests pass
 - [ ] There is a link to a successful Jenkins build
-- [ ] No new npm audit issues, or new issues have been added to [Front-end build process](https://confluence.niis.org/display/XRDDEV/Front-end+build+process) tracking table and accepted
+- [ ] No new npm audit issues, or needed "accepted audit vulnerabilities" have been added
+  - to [tracking table in Confluence](https://confluence.niis.org/display/XRDDEV/Accepted+npm+audit+vulnerabilities)
+  - to [audit-resolve.json](https://confluence.niis.org/display/XRDDEV/Front-end+build+process#Front-endbuildprocess-Resolvingauditfailures) file in version control
+  - you have crosschecked that these match  
+- [ ] If I fixed npm audit issues, I have updated "accepted audit vulnerabilities" as described above
 - [ ] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
 - [ ] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
 - [ ] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")
+

--- a/src/proxy-ui-api/build.gradle
+++ b/src/proxy-ui-api/build.gradle
@@ -83,7 +83,7 @@ node {
     nodeModulesDir = file("frontend/node_modules")
 }
 
-task buildFront(type: NpmTask, dependsOn: 'npmInstall') {
+task buildFront(type: NpmTask) {
     onlyIf {
         !project.hasProperty('skip-frontend-build')
     }
@@ -95,9 +95,25 @@ task buildFront(type: NpmTask, dependsOn: 'npmInstall') {
     }
 }
 
+// check that npm run check-audit passes
+// check-audit uses ignores from audit-resolve.json
+task checkFrontAudit(type: NpmTask, dependsOn: 'npmInstall') {
+    onlyIf {
+        !project.hasProperty('skip-frontend-build')
+    }
+    inputs.dir("frontend")
+    outputs.dir("frontend/dist")
+    args = ['run', 'check-audit']
+    execOverrides {
+        it.workingDir = 'frontend'
+    }
+}
+
 npmInstall.onlyIf { !project.hasProperty('skip-frontend-build') }
 
+// checkFrontAudit -> buildFront -> processResources
 processResources.dependsOn 'buildFront'
+buildFront.dependsOn 'checkFrontAudit'
 
 clean.delete << file('frontend/node_modules')
 clean.delete << file('frontend/dist')

--- a/src/proxy-ui-api/frontend/audit-resolve.json
+++ b/src/proxy-ui-api/frontend/audit-resolve.json
@@ -1,0 +1,371 @@
+{
+  "decisions": {
+    "146|@vue/cli-plugin-e2e-nightwatch>nightwatch>mocha-nightwatch>growl": {
+      "decision": "ignore",
+      "madeAt": 1571741364817,
+      "expiresAt": 1574333313233
+    },
+    "534|@vue/cli-plugin-e2e-nightwatch>nightwatch>mocha-nightwatch>debug": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "593|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>https-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "593|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>pac-proxy-agent>https-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "607|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>http-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "607|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>pac-proxy-agent>http-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "1068|@vue/cli-plugin-e2e-nightwatch>nightwatch>lodash.defaultsdeep": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "1070|@vue/cli-plugin-e2e-nightwatch>nightwatch>lodash.defaultsdeep": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "1184|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>https-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "1184|@vue/cli-plugin-e2e-nightwatch>nightwatch>proxy-agent>pac-proxy-agent>https-proxy-agent": {
+      "decision": "ignore",
+      "madeAt": 1571741364818,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>babel-jest>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373921,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>babel-jest>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>babel-jest>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>babel-jest>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>babel-jest>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>babel-plugin-istanbul>test-exclude>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-environment-jsdom>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-environment-jsdom>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-environment-jsdom>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-environment-jsdom>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-environment-jsdom>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-environment-node>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-environment-node>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-environment-node>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-environment-node>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-jasmine2>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-jasmine2>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-jasmine2>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-jasmine2>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-jasmine2>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-util>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-jasmine2>expect>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-jasmine2>expect>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-jasmine2>expect>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-jasmine2>expect>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-jasmine2>expect>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-jasmine2>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-jasmine2>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-jasmine2>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-jasmine2>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373922,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-jasmine2>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>jest-jasmine2>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>jest-jasmine2>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>jest-jasmine2>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>jest-jasmine2>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-jasmine2>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-resolve-dependencies>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-snapshot>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-message-util>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-config>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-config>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-config>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-config>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-haste-map>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-haste-map>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>jest-haste-map>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>jest-haste-map>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runner>jest-runtime>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>jest-runtime>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    },
+    "786|@vue/cli-plugin-unit-jest>jest>jest-cli>micromatch>braces": {
+      "decision": "ignore",
+      "madeAt": 1571741373923,
+      "expiresAt": 1574333313233
+    }
+  },
+  "rules": {},
+  "version": 1
+}

--- a/src/proxy-ui-api/frontend/package-lock.json
+++ b/src/proxy-ui-api/frontend/package-lock.json
@@ -903,6 +903,13 @@
         "postcss": "^7.0.0"
       }
     },
+    "@korzio/djv-draft-04": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz",
+      "integrity": "sha512-MeTVcNsfCIYxK6T7jW1sroC7dBAb4IfLmQe6RoCqlxHN5NFkzNpgdnBPR+/0D2wJDUJHM9s9NQv+ouhxKjvUjg==",
+      "dev": true,
+      "optional": true
+    },
     "@mdi/font": {
       "version": "4.4.95",
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.4.95.tgz",
@@ -2066,6 +2073,51 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "audit-resolve-core": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/audit-resolve-core/-/audit-resolve-core-1.1.7.tgz",
+      "integrity": "sha512-9nLm9SgyMbMv86X5a/E6spcu3V+suceHF6Pg4BwjPqfxWBKDvISagJH9Ji592KihqBev4guKFO3BiNEVNnqh3A==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.6.2",
+        "debug": "^4.1.1",
+        "djv": "^2.1.2",
+        "spawn-shell": "^2.1.0",
+        "yargs-parser": "^10.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "autoprefixer": {
       "version": "9.6.1",
@@ -4477,6 +4529,12 @@
         "strip-bom": "^2.0.0"
       }
     },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -4648,6 +4706,15 @@
       "dev": true,
       "requires": {
         "path-type": "^3.0.0"
+      }
+    },
+    "djv": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/djv/-/djv-2.1.2.tgz",
+      "integrity": "sha512-ltQSINn+7aMTp7pKeQpfZg2ACd/Gy6VrL3LYuT25/plwPBb7xlGOekr463Luqn816AWJLuP7KZQGFct2JICyeA==",
+      "dev": true,
+      "requires": {
+        "@korzio/djv-draft-04": "^2.0.1"
       }
     },
     "dns-equal": {
@@ -9096,6 +9163,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha1-T80kbcXQ44aRkHxEqwAveC0dlMw=",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -9644,6 +9717,15 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
+    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -9961,6 +10043,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "mz": {
@@ -10338,6 +10426,33 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
+    },
+    "npm-audit-resolver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/npm-audit-resolver/-/npm-audit-resolver-2.0.1.tgz",
+      "integrity": "sha512-8tV9j3A+XicxWo4vv9JczIp7mf99ezXPAKN3d1KmsIwspvAozEzaeMoF+Eo7OgubIYqhdGILnpZ7NpS8EW3C8g==",
+      "dev": true,
+      "requires": {
+        "audit-resolve-core": "^1.1.7",
+        "chalk": "^2.4.2",
+        "djv": "^2.1.2",
+        "jsonlines": "^0.1.1",
+        "read": "^1.0.7",
+        "spawn-shell": "^2.1.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -11974,6 +12089,15 @@
         "unpipe": "1.0.0"
       }
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -13208,6 +13332,17 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "spawn-shell": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.1.0.tgz",
+      "integrity": "sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==",
+      "dev": true,
+      "requires": {
+        "default-shell": "^1.0.1",
+        "merge-options": "~1.0.1",
+        "npm-run-path": "^2.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/src/proxy-ui-api/frontend/package.json
+++ b/src/proxy-ui-api/frontend/package.json
@@ -9,7 +9,9 @@
     "build:report": "vue-cli-service build --report",
     "test:coverage": "vue-cli-service test:unit --coverage",
     "test:e2e": "vue-cli-service test:e2e",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "check-audit": "check-audit",
+    "resolve-audit": "resolve-audit"
   },
   "dependencies": {
     "axios": "^0.19.0",
@@ -36,6 +38,7 @@
     "@vue/test-utils": "^1.0.0-beta.20",
     "babel-core": "7.0.0-bridge.0",
     "node-sass": "^4.12.0",
+    "npm-audit-resolver": "2.0.1",
     "sass": "^1.17.4",
     "sass-loader": "^7.3.1",
     "ts-jest": "^24.0.2",


### PR DESCRIPTION
## Description

Use npm-audit-resolver to ignore npm audit errors we don't want to break builds.

https://jira.niis.org/browse/XRDDEV-317

jenkins: https://jenkins.niis.org/view/api-based-ui/job/rest-ui-build-pull-request/117/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [x] I have made corresponding changes to the documentation
- [x] The new code has sufficient test coverage
- [x] The build, unit and integration tests pass
- [x] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or new issues have been added to [Front-end build process](https://confluence.niis.org/display/XRDDEV/Front-end+build+process) tracking table and accepted
- [x] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [x] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [x] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")
