### PR TITLE
XRDDEV-729 make client/id/sign-certificates return only sign certific…

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/TokenService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/TokenService.java
@@ -27,6 +27,7 @@ package org.niis.xroad.restapi.service;
 import ee.ria.xroad.common.CodedException;
 import ee.ria.xroad.common.conf.serverconf.model.ClientType;
 import ee.ria.xroad.signer.protocol.dto.CertificateInfo;
+import ee.ria.xroad.signer.protocol.dto.KeyInfo;
 import ee.ria.xroad.signer.protocol.dto.TokenInfo;
 
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import static ee.ria.xroad.common.ErrorCodes.SIGNER_X;
 import static ee.ria.xroad.common.ErrorCodes.X_LOGIN_FAILED;
@@ -80,6 +82,19 @@ public class TokenService {
     }
 
     /**
+     * get all sign certificates for a given client.
+     *
+     * @param clientType client who's member certificates need to be
+     *                   linked to
+     * @return
+     * @throws Exception
+     */
+    @PreAuthorize("hasAuthority('VIEW_CLIENT_DETAILS')")
+    public List<CertificateInfo> getSignCertificates(ClientType clientType) {
+        return getCertificates(clientType, true);
+    }
+
+    /**
      * get all certificates for a given client.
      *
      * @param clientType client who's member certificates need to be
@@ -88,14 +103,30 @@ public class TokenService {
      * @throws Exception
      */
     @PreAuthorize("hasAuthority('VIEW_CLIENT_DETAILS')")
-    public List<CertificateInfo> getAllCertificates(ClientType clientType) throws Exception {
+    public List<CertificateInfo> getAllCertificates(ClientType clientType) {
+        return getCertificates(clientType, false);
+    }
+
+    /**
+     * Get all certificates for a given client
+     * @param clientType
+     * @param onlySignCertificates if true, return only signing certificates
+     * @return
+     */
+    private List<CertificateInfo> getCertificates(ClientType clientType, boolean onlySignCertificates) {
         List<TokenInfo> tokenInfos = getAllTokens();
+        Predicate<KeyInfo> keyInfoPredicate = keyInfo -> true;
+        if (onlySignCertificates) {
+            keyInfoPredicate = keyInfo -> keyInfo.isForSigning();
+        }
         return tokenInfos.stream()
                 .flatMap(tokenInfo -> tokenInfo.getKeyInfo().stream())
+                .filter(keyInfoPredicate)
                 .flatMap(keyInfo -> keyInfo.getCerts().stream())
                 .filter(certificateInfo -> clientType.getIdentifier().memberEquals(certificateInfo.getMemberId()))
                 .collect(toList());
     }
+
 
     /**
      * Activate a token

--- a/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
+++ b/src/proxy-ui-api/src/main/resources/openapi-definition.yaml
@@ -5,7 +5,7 @@ servers:
     url: https://virtserver.swaggerhub.com/Gofore/X-Road/1.0.0
 info:
   description: X-Road UI Based API
-  version: "1.0.12"
+  version: "1.0.13"
   title: X-Road UI Based API
   contact:
     email: lauri.koutaniemi@gofore.com
@@ -860,7 +860,7 @@ paths:
       tags:
         - security server
       summary: get security server client certificates information
-      operationId: getClientCertificates
+      operationId: getClientSignCertificates
       description: Administrator views the certificates for the client.
       parameters:
         - in: path
@@ -882,7 +882,7 @@ paths:
                 uniqueItems: true
                 description: array of certificate (details) objects
                 items:
-                  $ref: '#/components/schemas/CertificateDetails'
+                  $ref: '#/components/schemas/TokenCertificate'
         '400':
           description: request was invalid
         '401':

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/openapi/ClientsApiControllerIntegrationTest.java
@@ -46,6 +46,7 @@ import org.niis.xroad.restapi.openapi.model.Service;
 import org.niis.xroad.restapi.openapi.model.ServiceDescription;
 import org.niis.xroad.restapi.openapi.model.ServiceDescriptionAdd;
 import org.niis.xroad.restapi.openapi.model.ServiceType;
+import org.niis.xroad.restapi.openapi.model.TokenCertificate;
 import org.niis.xroad.restapi.service.TokenService;
 import org.niis.xroad.restapi.service.WsdlUrlValidator;
 import org.niis.xroad.restapi.util.CertificateTestUtils;
@@ -223,36 +224,38 @@ public class ClientsApiControllerIntegrationTest {
 
     @Test
     @WithMockUser(authorities = "VIEW_CLIENT_DETAILS")
-    public void getClientCertificates() throws Exception {
-        ResponseEntity<List<CertificateDetails>> certificates =
-                clientsApiController.getClientCertificates("FI:GOV:M1");
+    public void getClientSignCertificates() throws Exception {
+        ResponseEntity<List<TokenCertificate>> certificates =
+                clientsApiController.getClientSignCertificates("FI:GOV:M1");
         assertEquals(HttpStatus.OK, certificates.getStatusCode());
         assertEquals(0, certificates.getBody().size());
         CertificateInfo mockCertificate = new CertificateInfo(
                 ClientId.create("FI", "GOV", "M1"),
                 true, true, CertificateInfo.STATUS_REGISTERED,
                 "id", CertificateTestUtils.getMockCertificateBytes(), null);
-        when(tokenService.getAllCertificates(any())).thenReturn(Collections.singletonList(mockCertificate));
+        when(tokenService.getSignCertificates(any())).thenReturn(Collections.singletonList(mockCertificate));
 
-        certificates = clientsApiController.getClientCertificates("FI:GOV:M1");
+        certificates = clientsApiController.getClientSignCertificates("FI:GOV:M1");
         assertEquals(HttpStatus.OK, certificates.getStatusCode());
         assertEquals(1, certificates.getBody().size());
-        CertificateDetails onlyCertificate = certificates.getBody().get(0);
-        assertEquals("N/A", onlyCertificate.getIssuerCommonName());
-        assertEquals(OffsetDateTime.parse("1970-01-01T00:00:00Z"), onlyCertificate.getNotBefore());
-        assertEquals(OffsetDateTime.parse("2038-01-01T00:00:00Z"), onlyCertificate.getNotAfter());
-        assertEquals("1", onlyCertificate.getSerial());
-        assertEquals(new Integer(3), onlyCertificate.getVersion());
-        assertEquals("SHA512withRSA", onlyCertificate.getSignatureAlgorithm());
-        assertEquals("RSA", onlyCertificate.getPublicKeyAlgorithm());
-        assertEquals("A2293825AA82A5429EC32803847E2152A303969C", onlyCertificate.getHash());
-        assertTrue(onlyCertificate.getSignature().startsWith("314b7a50a09a9b74322671"));
-        assertTrue(onlyCertificate.getRsaPublicKeyModulus().startsWith("9d888fbe089b32a35f58"));
-        assertEquals(new Integer(65537), onlyCertificate.getRsaPublicKeyExponent());
+        TokenCertificate onlyCertificate = certificates.getBody().get(0);
+        assertEquals("N/A", onlyCertificate.getCertificateDetails().getIssuerCommonName());
+        assertEquals(OffsetDateTime.parse("1970-01-01T00:00:00Z"),
+                onlyCertificate.getCertificateDetails().getNotBefore());
+        assertEquals(OffsetDateTime.parse("2038-01-01T00:00:00Z"),
+                onlyCertificate.getCertificateDetails().getNotAfter());
+        assertEquals("1", onlyCertificate.getCertificateDetails().getSerial());
+        assertEquals(new Integer(3), onlyCertificate.getCertificateDetails().getVersion());
+        assertEquals("SHA512withRSA", onlyCertificate.getCertificateDetails().getSignatureAlgorithm());
+        assertEquals("RSA", onlyCertificate.getCertificateDetails().getPublicKeyAlgorithm());
+        assertEquals("A2293825AA82A5429EC32803847E2152A303969C", onlyCertificate.getCertificateDetails().getHash());
+        assertTrue(onlyCertificate.getCertificateDetails().getSignature().startsWith("314b7a50a09a9b74322671"));
+        assertTrue(onlyCertificate.getCertificateDetails().getRsaPublicKeyModulus().startsWith("9d888fbe089b32a35f58"));
+        assertEquals(new Integer(65537), onlyCertificate.getCertificateDetails().getRsaPublicKeyExponent());
         assertEquals(new ArrayList<>(Arrays.asList(org.niis.xroad.restapi.openapi.model.KeyUsage.NON_REPUDIATION)),
-                new ArrayList<>(onlyCertificate.getKeyUsages()));
+                new ArrayList<>(onlyCertificate.getCertificateDetails().getKeyUsages()));
         try {
-            certificates = clientsApiController.getClientCertificates("FI:GOV:M2");
+            certificates = clientsApiController.getClientSignCertificates("FI:GOV:M2");
             fail("should throw ResourceNotFoundException for 404");
         } catch (ResourceNotFoundException expected) {
         }

--- a/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/TokenServiceTest.java
+++ b/src/proxy-ui-api/src/test/java/org/niis/xroad/restapi/service/TokenServiceTest.java
@@ -149,7 +149,7 @@ public class TokenServiceTest {
 
     @Test
     @WithMockUser(authorities = { "DEACTIVATE_TOKEN" })
-    public void deactiveToken() throws Exception {
+    public void deactivateToken() throws Exception {
         tokenService.deactivateToken("token-should-be-deactivatable");
 
         try {


### PR DESCRIPTION
…ates, not tls certificates

## Description

https://jira.niis.org/browse/XRDDEV-729

jenkins: https://jenkins.niis.org/view/api-based-ui/job/rest-ui-build-pull-request/121/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [x] I have made corresponding changes to the documentation
- [x] The new code has sufficient test coverage
- [x] The build, unit and integration tests pass
- [x] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or needed "accepted audit vulnerabilities" have been added
  - to [tracking table in Confluence](https://confluence.niis.org/display/XRDDEV/Accepted+npm+audit+vulnerabilities)
  - to [audit-resolve.json](https://confluence.niis.org/display/XRDDEV/Front-end+build+process#Front-endbuildprocess-Resolvingauditfailures) file in version control
  - you have crosschecked that these match  
- [x] If I fixed npm audit issues, I have updated "accepted audit vulnerabilities" as described above
- [x] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [x] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [x] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")

