### PR TITLE
XRDDEV-584 SOAP ACL // LocalGroupId fix

### DIFF
--- a/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/IdentifierService.java
+++ b/src/proxy-ui-api/src/main/java/org/niis/xroad/restapi/service/IdentifierService.java
@@ -61,13 +61,23 @@ public class IdentifierService {
      */
     @PreAuthorize("hasAuthority('EDIT_SERVICE_ACL')")
     public Set<XRoadId> getOrPersistXroadIds(Set<XRoadId> xRoadIds) {
-        Collection<XRoadId> allIdsFromDb = identifierRepository.getIdentifiers();
-        Set<XRoadId> txEntities = allIdsFromDb.stream()
-                .filter(xRoadIds::contains) // this works because of the XRoadId equals and hashCode overrides
-                .collect(Collectors.toSet());
+        Set<XRoadId> txEntities = getXroadIds(xRoadIds);
         xRoadIds.removeAll(txEntities); // remove the persistent ones
         identifierRepository.saveOrUpdate(xRoadIds); // persist the non-persisted
         txEntities.addAll(xRoadIds); // add the newly persisted ids into the collection of already existing ids
         return txEntities;
+    }
+
+    /**
+     * Get the existing {@link XRoadId xRoadIds} from the local db
+     * @param xRoadIds
+     * @return List of XRoadIds
+     */
+    @PreAuthorize("hasAuthority('EDIT_SERVICE_ACL')")
+    public Set<XRoadId> getXroadIds(Set<XRoadId> xRoadIds) {
+        Collection<XRoadId> allIdsFromDb = identifierRepository.getIdentifiers();
+        return allIdsFromDb.stream()
+                .filter(xRoadIds::contains) // this works because of the XRoadId equals and hashCode overrides
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
## Description

`LocalGroupId` is now persisted when adding a new access right

Jenkins build: https://jenkins.niis.org/view/api-based-ui/job/rest-ui-build-pull-request/131/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the agreed [Version Control Practices](https://confluence.niis.org/pages/viewpage.action?spaceKey=XRDDEV&title=Version+Control+Practices)
- [x] My changes generate no new warnings or errors (e.g. Javascript console, Java stdout)
- [x] I have made corresponding changes to the documentation
- [x] The new code has sufficient test coverage
- [x] The build, unit and integration tests pass
- [x] There is a link to a successful Jenkins build
- [x] No new npm audit issues, or needed "accepted audit vulnerabilities" have been added
  - to [tracking table in Confluence](https://confluence.niis.org/display/XRDDEV/Accepted+npm+audit+vulnerabilities)
  - to [audit-resolve.json](https://confluence.niis.org/display/XRDDEV/Front-end+build+process#Front-endbuildprocess-Resolvingauditfailures) file in version control
  - you have crosschecked that these match  
- [x] If I fixed npm audit issues, I have updated "accepted audit vulnerabilities" as described above
- [x] New backlog items that have been created (such as "not implementing this acceptance criteria now") are mentioned + linked in Jira task comments
- [x] All task outputs (PR, documentation, UI design, etc) is listed in a Jira comment so that it is easy for reviewer to check
- [x] Deviations from acceptance criteria listed in comments (also if "this criteria was removed")

